### PR TITLE
Return alpha+1 in qsearch.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1191,9 +1191,10 @@ moves_loop: // When in check, search starts from here
     moveCount = 0;
 
     // Check for an immediate draw or maximum ply reached
-    if (   pos.is_draw(ss->ply)
-        || ss->ply >= MAX_PLY)
-        return (ss->ply >= MAX_PLY && !InCheck) ? evaluate(pos) : VALUE_DRAW;
+    if (pos.is_draw(ss->ply))
+         return VALUE_DRAW;
+    if (ss->ply >= MAX_PLY)
+         return InCheck ? alpha+1 : evaluate(pos);
 
     assert(0 <= ss->ply && ss->ply < MAX_PLY);
 


### PR DESCRIPTION
Fix bug in qsearch where VALUE_DRAW was returned on long searches
that reached MAX_PLY with a check.

Bench: 5934644